### PR TITLE
Add Text and Binary marshalling interfaces

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_call:
 
 jobs:
   benchmark:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_call:
 
 jobs:
   golangci:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_call:
 
 jobs:
   test:
@@ -55,7 +56,7 @@ jobs:
     - name: Upload coverage to Codecov (optional)
       uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.out
+        files: ./coverage.out
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,45 @@
+package enum
+
+import (
+	"github.com/gmllt/enum/internal"
+)
+
+// Re-export internal error types for public use.
+// This allows users of the library to check for specific error types
+// using errors.Is() or errors.As().
+
+// ErrInvalidEnumValue is returned when trying to unmarshal an invalid enum value.
+// It provides information about the invalid value and the list of valid values.
+type ErrInvalidEnumValue = internal.ErrInvalidEnumValue
+
+// ErrBinaryDataTooShort is returned when binary data is too short to contain valid data.
+type ErrBinaryDataTooShort = internal.ErrBinaryDataTooShort
+
+// ErrBinaryDataTruncated is returned when binary data is truncated.
+type ErrBinaryDataTruncated = internal.ErrBinaryDataTruncated
+
+// ErrLabelTooLong is returned when a label exceeds the maximum allowed length for binary encoding.
+type ErrLabelTooLong = internal.ErrLabelTooLong
+
+// Helper functions for creating error instances (optional, for convenience).
+
+// NewInvalidEnumValueError creates a new ErrInvalidEnumValue.
+// This is provided for convenience, though users typically won't need to create these errors manually.
+func NewInvalidEnumValueError(value string, validValues []string) *ErrInvalidEnumValue {
+	return internal.NewInvalidEnumValueError(value, validValues)
+}
+
+// NewBinaryDataTooShortError creates a new ErrBinaryDataTooShort.
+func NewBinaryDataTooShortError(expected, actual int) *ErrBinaryDataTooShort {
+	return internal.NewBinaryDataTooShortError(expected, actual)
+}
+
+// NewBinaryDataTruncatedError creates a new ErrBinaryDataTruncated.
+func NewBinaryDataTruncatedError(expected, actual int) *ErrBinaryDataTruncated {
+	return internal.NewBinaryDataTruncatedError(expected, actual)
+}
+
+// NewLabelTooLongError creates a new ErrLabelTooLong.
+func NewLabelTooLongError(length, maxLength int) *ErrLabelTooLong {
+	return internal.NewLabelTooLongError(length, maxLength)
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -1,0 +1,117 @@
+package enum
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestPublicErrorTypes tests that the public error types work correctly.
+func TestPublicErrorTypes(t *testing.T) {
+	// Test that we can create and use public error types
+	invalidErr := NewInvalidEnumValueError("invalid", []string{"valid1", "valid2"})
+	binaryShortErr := NewBinaryDataTooShortError(4, 2)
+	binaryTruncatedErr := NewBinaryDataTruncatedError(10, 5)
+	labelTooLongErr := NewLabelTooLongError(70000, 65535)
+
+	// Test that errors.Is works with public types
+	var targetInvalid *ErrInvalidEnumValue
+	if !errors.As(invalidErr, &targetInvalid) {
+		t.Error("should be able to cast to public ErrInvalidEnumValue type")
+	}
+
+	var targetBinaryShort *ErrBinaryDataTooShort
+	if !errors.As(binaryShortErr, &targetBinaryShort) {
+		t.Error("should be able to cast to public ErrBinaryDataTooShort type")
+	}
+
+	var targetBinaryTruncated *ErrBinaryDataTruncated
+	if !errors.As(binaryTruncatedErr, &targetBinaryTruncated) {
+		t.Error("should be able to cast to public ErrBinaryDataTruncated type")
+	}
+
+	var targetLabelTooLong *ErrLabelTooLong
+	if !errors.As(labelTooLongErr, &targetLabelTooLong) {
+		t.Error("should be able to cast to public ErrLabelTooLong type")
+	}
+
+	// Test error messages
+	expectedInvalidMsg := `invalid enum value: "invalid" (valid values: [valid1 valid2])`
+	if invalidErr.Error() != expectedInvalidMsg {
+		t.Errorf("expected %q, got %q", expectedInvalidMsg, invalidErr.Error())
+	}
+
+	expectedBinaryShortMsg := "binary data too short: expected at least 4 bytes, got 2"
+	if binaryShortErr.Error() != expectedBinaryShortMsg {
+		t.Errorf("expected %q, got %q", expectedBinaryShortMsg, binaryShortErr.Error())
+	}
+}
+
+// TestErrorIntegrationWithWrapper tests that wrapper methods return the correct error types.
+func TestErrorIntegrationWithWrapper(t *testing.T) {
+	wrapper := NewWrapper[int]("red", "green", "blue")
+
+	// Test JSON unmarshalling with invalid value
+	err := wrapper.UnmarshalJSON([]byte(`"yellow"`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON value")
+	}
+
+	var invalidErr *ErrInvalidEnumValue
+	if !errors.As(err, &invalidErr) {
+		t.Errorf("expected ErrInvalidEnumValue, got %T: %v", err, err)
+	} else {
+		if invalidErr.Value != "yellow" {
+			t.Errorf("expected invalid value 'yellow', got %q", invalidErr.Value)
+		}
+		if len(invalidErr.ValidValues) != 3 {
+			t.Errorf("expected 3 valid values, got %d", len(invalidErr.ValidValues))
+		}
+	}
+
+	// Test binary unmarshalling with too short data
+	err = wrapper.UnmarshalBinary([]byte{})
+	if err == nil {
+		t.Fatal("expected error for empty binary data")
+	}
+
+	var binaryShortErr *ErrBinaryDataTooShort
+	if !errors.As(err, &binaryShortErr) {
+		t.Errorf("expected ErrBinaryDataTooShort, got %T: %v", err, err)
+	} else {
+		if binaryShortErr.Expected != 2 || binaryShortErr.Actual != 0 {
+			t.Errorf("expected Expected=2, Actual=0, got Expected=%d, Actual=%d",
+				binaryShortErr.Expected, binaryShortErr.Actual)
+		}
+	}
+
+	// Test binary unmarshalling with truncated data
+	err = wrapper.UnmarshalBinary([]byte{0, 10, 'a', 'b'}) // claims 10 bytes but only has 2
+	if err == nil {
+		t.Fatal("expected error for truncated binary data")
+	}
+
+	var binaryTruncatedErr *ErrBinaryDataTruncated
+	if !errors.As(err, &binaryTruncatedErr) {
+		t.Errorf("expected ErrBinaryDataTruncated, got %T: %v", err, err)
+	} else {
+		if binaryTruncatedErr.Expected != 12 || binaryTruncatedErr.Actual != 4 {
+			t.Errorf("expected Expected=12, Actual=4, got Expected=%d, Actual=%d",
+				binaryTruncatedErr.Expected, binaryTruncatedErr.Actual)
+		}
+	}
+
+	// Test text unmarshalling with invalid value
+	err = wrapper.UnmarshalText([]byte("purple"))
+	if err == nil {
+		t.Fatal("expected error for invalid text value")
+	}
+
+	var textInvalidErr *ErrInvalidEnumValue
+	if !errors.As(err, &textInvalidErr) {
+		t.Errorf("expected ErrInvalidEnumValue for text, got %T: %v", err, err)
+	} else {
+		if textInvalidErr.Value != "purple" {
+			t.Errorf("expected invalid value 'purple', got %q", textInvalidErr.Value)
+		}
+	}
+}

--- a/internal/errors.go
+++ b/internal/errors.go
@@ -1,0 +1,108 @@
+package internal
+
+import (
+	"fmt"
+)
+
+// ErrInvalidEnumValue is returned when trying to unmarshal an invalid enum value.
+type ErrInvalidEnumValue struct {
+	Value       string
+	ValidValues []string
+}
+
+func (e *ErrInvalidEnumValue) Error() string {
+	if len(e.ValidValues) == 0 {
+		return fmt.Sprintf("invalid enum value: %q (no valid values available)", e.Value)
+	}
+	return fmt.Sprintf("invalid enum value: %q (valid values: %v)", e.Value, e.ValidValues)
+}
+
+// Is implements the errors.Is interface for error comparison.
+func (e *ErrInvalidEnumValue) Is(target error) bool {
+	_, ok := target.(*ErrInvalidEnumValue)
+	return ok
+}
+
+// ErrBinaryDataTooShort is returned when binary data is too short to contain valid data.
+type ErrBinaryDataTooShort struct {
+	Expected int
+	Actual   int
+}
+
+func (e *ErrBinaryDataTooShort) Error() string {
+	return fmt.Sprintf("binary data too short: expected at least %d bytes, got %d", e.Expected, e.Actual)
+}
+
+// Is implements the errors.Is interface for error comparison.
+func (e *ErrBinaryDataTooShort) Is(target error) bool {
+	_, ok := target.(*ErrBinaryDataTooShort)
+	return ok
+}
+
+// ErrBinaryDataTruncated is returned when binary data is truncated.
+type ErrBinaryDataTruncated struct {
+	Expected int
+	Actual   int
+}
+
+func (e *ErrBinaryDataTruncated) Error() string {
+	return fmt.Sprintf("binary data truncated: expected %d bytes, got %d", e.Expected, e.Actual)
+}
+
+// Is implements the errors.Is interface for error comparison.
+func (e *ErrBinaryDataTruncated) Is(target error) bool {
+	_, ok := target.(*ErrBinaryDataTruncated)
+	return ok
+}
+
+// ErrLabelTooLong is returned when a label exceeds the maximum allowed length for binary encoding.
+type ErrLabelTooLong struct {
+	Length    int
+	MaxLength int
+}
+
+func (e *ErrLabelTooLong) Error() string {
+	return fmt.Sprintf("label too long: %d bytes (max %d)", e.Length, e.MaxLength)
+}
+
+// Is implements the errors.Is interface for error comparison.
+func (e *ErrLabelTooLong) Is(target error) bool {
+	_, ok := target.(*ErrLabelTooLong)
+	return ok
+}
+
+// NewInvalidEnumValueError creates a new ErrInvalidEnumValue.
+func NewInvalidEnumValueError(value string, validValues []string) *ErrInvalidEnumValue {
+	// Create a copy of validValues to avoid external modifications
+	validValuesCopy := make([]string, len(validValues))
+	copy(validValuesCopy, validValues)
+
+	return &ErrInvalidEnumValue{
+		Value:       value,
+		ValidValues: validValuesCopy,
+	}
+}
+
+// NewBinaryDataTooShortError creates a new ErrBinaryDataTooShort.
+func NewBinaryDataTooShortError(expected, actual int) *ErrBinaryDataTooShort {
+	return &ErrBinaryDataTooShort{
+		Expected: expected,
+		Actual:   actual,
+	}
+}
+
+// NewBinaryDataTruncatedError creates a new ErrBinaryDataTruncated.
+func NewBinaryDataTruncatedError(expected, actual int) *ErrBinaryDataTruncated {
+	return &ErrBinaryDataTruncated{
+		Expected: expected,
+		Actual:   actual,
+	}
+}
+
+// NewLabelTooLongError creates a new ErrLabelTooLong.
+func NewLabelTooLongError(length, maxLength int) *ErrLabelTooLong {
+	return &ErrLabelTooLong{
+		Length:    length,
+		MaxLength: maxLength,
+	}
+}

--- a/internal/errors_test.go
+++ b/internal/errors_test.go
@@ -1,0 +1,133 @@
+package internal
+
+import (
+	"errors"
+	"testing"
+)
+
+// TestErrInvalidEnumValue tests the ErrInvalidEnumValue error type.
+func TestErrInvalidEnumValue(t *testing.T) {
+	validValues := []string{"red", "green", "blue"}
+	err := NewInvalidEnumValueError("yellow", validValues)
+
+	// Test error message
+	expectedMsg := `invalid enum value: "yellow" (valid values: [red green blue])`
+	if err.Error() != expectedMsg {
+		t.Errorf("expected error message %q, got %q", expectedMsg, err.Error())
+	}
+
+	// Test Is method
+	var target *ErrInvalidEnumValue
+	if !errors.As(err, &target) {
+		t.Error("expected error to be of type *ErrInvalidEnumValue")
+	}
+
+	// Test that modifying original slice doesn't affect error
+	validValues[0] = "modified"
+	if err.ValidValues[0] != "red" {
+		t.Error("error's ValidValues should not be affected by external modifications")
+	}
+}
+
+// TestErrInvalidEnumValueEmpty tests ErrInvalidEnumValue with empty valid values.
+func TestErrInvalidEnumValueEmpty(t *testing.T) {
+	err := NewInvalidEnumValueError("test", []string{})
+
+	expectedMsg := `invalid enum value: "test" (no valid values available)`
+	if err.Error() != expectedMsg {
+		t.Errorf("expected error message %q, got %q", expectedMsg, err.Error())
+	}
+}
+
+// TestErrBinaryDataTooShort tests the ErrBinaryDataTooShort error type.
+func TestErrBinaryDataTooShort(t *testing.T) {
+	err := NewBinaryDataTooShortError(4, 2)
+
+	expectedMsg := "binary data too short: expected at least 4 bytes, got 2"
+	if err.Error() != expectedMsg {
+		t.Errorf("expected error message %q, got %q", expectedMsg, err.Error())
+	}
+
+	// Test Is method
+	var target *ErrBinaryDataTooShort
+	if !errors.As(err, &target) {
+		t.Error("expected error to be of type *ErrBinaryDataTooShort")
+	}
+
+	if target.Expected != 4 || target.Actual != 2 {
+		t.Errorf("expected Expected=4, Actual=2, got Expected=%d, Actual=%d", target.Expected, target.Actual)
+	}
+}
+
+// TestErrBinaryDataTruncated tests the ErrBinaryDataTruncated error type.
+func TestErrBinaryDataTruncated(t *testing.T) {
+	err := NewBinaryDataTruncatedError(10, 5)
+
+	expectedMsg := "binary data truncated: expected 10 bytes, got 5"
+	if err.Error() != expectedMsg {
+		t.Errorf("expected error message %q, got %q", expectedMsg, err.Error())
+	}
+
+	// Test Is method
+	var target *ErrBinaryDataTruncated
+	if !errors.As(err, &target) {
+		t.Error("expected error to be of type *ErrBinaryDataTruncated")
+	}
+
+	if target.Expected != 10 || target.Actual != 5 {
+		t.Errorf("expected Expected=10, Actual=5, got Expected=%d, Actual=%d", target.Expected, target.Actual)
+	}
+}
+
+// TestErrLabelTooLong tests the ErrLabelTooLong error type.
+func TestErrLabelTooLong(t *testing.T) {
+	err := NewLabelTooLongError(70000, 65535)
+
+	expectedMsg := "label too long: 70000 bytes (max 65535)"
+	if err.Error() != expectedMsg {
+		t.Errorf("expected error message %q, got %q", expectedMsg, err.Error())
+	}
+
+	// Test Is method
+	var target *ErrLabelTooLong
+	if !errors.As(err, &target) {
+		t.Error("expected error to be of type *ErrLabelTooLong")
+	}
+
+	if target.Length != 70000 || target.MaxLength != 65535 {
+		t.Errorf("expected Length=70000, MaxLength=65535, got Length=%d, MaxLength=%d", target.Length, target.MaxLength)
+	}
+}
+
+// TestErrorTypeComparison tests that different error types can be distinguished.
+func TestErrorTypeComparison(t *testing.T) {
+	invalidValueErr := NewInvalidEnumValueError("test", []string{"valid"})
+	binaryShortErr := NewBinaryDataTooShortError(4, 2)
+	binaryTruncatedErr := NewBinaryDataTruncatedError(10, 5)
+	labelTooLongErr := NewLabelTooLongError(70000, 65535)
+
+	// Test that each error type is distinct
+	if errors.Is(invalidValueErr, binaryShortErr) {
+		t.Error("ErrInvalidEnumValue should not be equal to ErrBinaryDataTooShort")
+	}
+
+	if errors.Is(binaryShortErr, binaryTruncatedErr) {
+		t.Error("ErrBinaryDataTooShort should not be equal to ErrBinaryDataTruncated")
+	}
+
+	if errors.Is(binaryTruncatedErr, labelTooLongErr) {
+		t.Error("ErrBinaryDataTruncated should not be equal to ErrLabelTooLong")
+	}
+
+	// Test that same error types are equal
+	anotherInvalidValueErr := NewInvalidEnumValueError("other", []string{"different"})
+	if !errors.Is(invalidValueErr, anotherInvalidValueErr) {
+		t.Error("Two ErrInvalidEnumValue instances should be considered equal via errors.Is")
+	}
+
+	// Test that same error types are equal for ErrLabelTooLong
+	anotherLabelTooLongErr := NewLabelTooLongError(50000, 32767)
+	if !errors.Is(labelTooLongErr, anotherLabelTooLongErr) {
+		t.Error("Two ErrLabelTooLong instances should be considered equal via errors.Is")
+	}
+}

--- a/internal/marshal.go
+++ b/internal/marshal.go
@@ -1,6 +1,8 @@
 package internal
 
 import (
+	"database/sql/driver"
+	"encoding/binary"
 	"encoding/json"
 )
 
@@ -23,7 +25,7 @@ func FromJSON[T ~int](labels []string, b []byte) (T, error) {
 	}
 
 	var zero T
-	return zero, nil
+	return zero, NewInvalidEnumValueError(s, labels)
 } // ToYAML serializes an enum value into YAML.
 func ToYAML[T ~int](labels []string, v T) (any, error) {
 	return SafeGetLabel(labels, v, InvalidLabel), nil
@@ -42,5 +44,93 @@ func FromYAML[T ~int](labels []string, unmarshal func(any) error) (T, error) {
 	}
 
 	var zero T
-	return zero, nil
+	return zero, NewInvalidEnumValueError(s, labels)
+}
+
+// ToText serializes an enum value into text (for encoding.TextMarshaler).
+func ToText[T ~int](labels []string, v T) ([]byte, error) {
+	label := SafeGetLabel(labels, v, InvalidLabel)
+	return []byte(label), nil
+}
+
+// FromText deserializes text into an enum value (for encoding.TextUnmarshaler).
+func FromText[T ~int](labels []string, text []byte) (T, error) {
+	s := string(text)
+	if val, found := StringToIndex[T](labels, s); found {
+		return val, nil
+	}
+
+	var zero T
+	return zero, NewInvalidEnumValueError(s, labels)
+}
+
+// ToBinary serializes an enum value into binary (for encoding.BinaryMarshaler).
+func ToBinary[T ~int](labels []string, v T) ([]byte, error) {
+	label := SafeGetLabel(labels, v, InvalidLabel)
+	// Store as length-prefixed string (2 bytes, big-endian) for efficiency
+	labelBytes := []byte(label)
+	if len(labelBytes) > 65535 {
+		return nil, NewLabelTooLongError(len(labelBytes), 65535)
+	}
+	result := make([]byte, 2+len(labelBytes))
+	binary.BigEndian.PutUint16(result[0:2], uint16(len(labelBytes)))
+	copy(result[2:], labelBytes)
+	return result, nil
+}
+
+// FromBinary deserializes binary into an enum value (for encoding.BinaryUnmarshaler).
+func FromBinary[T ~int](labels []string, data []byte) (T, error) {
+	var zero T
+
+	if len(data) < 2 {
+		return zero, NewBinaryDataTooShortError(2, len(data))
+	}
+
+	// Read length-prefixed string (2 bytes, big-endian)
+	length := int(binary.BigEndian.Uint16(data[0:2]))
+	if len(data) < 2+length {
+		return zero, NewBinaryDataTruncatedError(2+length, len(data))
+	}
+
+	label := string(data[2 : 2+length])
+	if val, found := StringToIndex[T](labels, label); found {
+		return val, nil
+	}
+
+	return zero, NewInvalidEnumValueError(label, labels)
+}
+
+// ToSQLValue serializes an enum value for SQL storage (for driver.Valuer).
+func ToSQLValue[T ~int](labels []string, v T) (driver.Value, error) {
+	if !IsValidIndex(labels, v) {
+		return nil, NewInvalidEnumValueError("", labels)
+	}
+	label := SafeGetLabel(labels, v, InvalidLabel)
+	return label, nil
+}
+
+// FromSQLValue deserializes an SQL value into an enum value (for sql.Scanner).
+func FromSQLValue[T ~int](labels []string, src any) (T, error) {
+	var zero T
+
+	if src == nil {
+		// SQL NULL maps to zero value
+		return zero, nil
+	}
+
+	var s string
+	switch v := src.(type) {
+	case string:
+		s = v
+	case []byte:
+		s = string(v)
+	default:
+		return zero, NewInvalidEnumValueError("non-string SQL value", labels)
+	}
+
+	if val, found := StringToIndex[T](labels, s); found {
+		return val, nil
+	}
+
+	return zero, NewInvalidEnumValueError(s, labels)
 }

--- a/internal/marshal_test.go
+++ b/internal/marshal_test.go
@@ -1,7 +1,9 @@
 package internal
 
 import (
+	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"reflect"
 	"testing"
 )
@@ -88,7 +90,7 @@ func TestFromJSON(t *testing.T) {
 			name:        "invalid label",
 			input:       `"yellow"`,
 			expectedVal: 0,
-			expectError: false, // Returns zero value, no error
+			expectError: true, // Now returns error for invalid values
 		},
 		{
 			name:        "invalid JSON",
@@ -106,7 +108,7 @@ func TestFromJSON(t *testing.T) {
 			name:        "empty string",
 			input:       `""`,
 			expectedVal: 0,
-			expectError: false, // Returns zero value for not found
+			expectError: true, // Now returns error for invalid values
 		},
 	}
 
@@ -212,7 +214,7 @@ func TestFromYAML(t *testing.T) {
 			name:        "invalid label",
 			input:       "fish",
 			expectedVal: 0,
-			expectError: false, // Returns zero value, no error
+			expectError: true, // Now returns error for invalid values
 		},
 		{
 			name:        "non-string input",
@@ -224,7 +226,7 @@ func TestFromYAML(t *testing.T) {
 			name:        "empty string",
 			input:       "",
 			expectedVal: 0,
-			expectError: false, // Returns zero value for not found
+			expectError: true, // Now returns error for invalid values
 		},
 	}
 
@@ -420,5 +422,450 @@ func TestMarshalLargeEnum(t *testing.T) {
 	expectedLabel := labels[30]
 	if yamlValue != expectedLabel {
 		t.Errorf("expected %q, got %v", expectedLabel, yamlValue)
+	}
+}
+
+// TestToText tests text marshalling
+func TestToText(t *testing.T) {
+	labels := []string{"first", "second", "third"}
+
+	tests := []struct {
+		name     string
+		value    int
+		expected string
+	}{
+		{
+			name:     "valid first value",
+			value:    0,
+			expected: "first",
+		},
+		{
+			name:     "valid second value",
+			value:    1,
+			expected: "second",
+		},
+		{
+			name:     "invalid value",
+			value:    10,
+			expected: InvalidLabel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ToText(labels, tt.value)
+			if err != nil {
+				t.Errorf("ToText failed: %v", err)
+				return
+			}
+
+			if string(result) != tt.expected {
+				t.Errorf("expected %q, got %q", tt.expected, string(result))
+			}
+		})
+	}
+}
+
+// TestFromText tests text unmarshalling
+func TestFromText(t *testing.T) {
+	labels := []string{"first", "second", "third"}
+
+	tests := []struct {
+		name      string
+		text      string
+		expected  int
+		wantError bool
+	}{
+		{
+			name:      "valid first label",
+			text:      "first",
+			expected:  0,
+			wantError: false,
+		},
+		{
+			name:      "valid second label",
+			text:      "second",
+			expected:  1,
+			wantError: false,
+		},
+		{
+			name:      "invalid label",
+			text:      "invalid",
+			expected:  0,    // zero value
+			wantError: true, // now expects error
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := FromText[int](labels, []byte(tt.text))
+
+			if tt.wantError {
+				if err == nil {
+					t.Errorf("expected error for invalid label, but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("FromText failed: %v", err)
+				return
+			}
+
+			if result != tt.expected {
+				t.Errorf("expected %d, got %d", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestToBinary tests binary marshalling
+func TestToBinary(t *testing.T) {
+	labels := []string{"first", "second", "third"}
+
+	tests := []struct {
+		name  string
+		value int
+		label string
+	}{
+		{
+			name:  "valid first value",
+			value: 0,
+			label: "first",
+		},
+		{
+			name:  "valid second value",
+			value: 1,
+			label: "second",
+		},
+		{
+			name:  "invalid value",
+			value: 10,
+			label: InvalidLabel,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ToBinary(labels, tt.value)
+			if err != nil {
+				t.Errorf("ToBinary failed: %v", err)
+				return
+			}
+
+			// Check format: first 2 bytes are length (big-endian), followed by string
+			expectedLen := uint16(len(tt.label))
+			if len(result) < 2 {
+				t.Errorf("result too short: expected at least 2 bytes, got %d", len(result))
+				return
+			}
+
+			actualLen := binary.BigEndian.Uint16(result[0:2])
+			if actualLen != expectedLen {
+				t.Errorf("expected length prefix %d, got %d", expectedLen, actualLen)
+				return
+			}
+
+			actualLabel := string(result[2:])
+			if actualLabel != tt.label {
+				t.Errorf("expected label %q, got %q", tt.label, actualLabel)
+			}
+		})
+	}
+}
+
+// TestFromBinary tests binary unmarshalling
+func TestFromBinary(t *testing.T) {
+	labels := []string{"first", "second", "third"}
+
+	tests := []struct {
+		name     string
+		data     []byte
+		expected int
+		wantErr  bool
+	}{
+		{
+			name:     "valid first label",
+			data:     []byte{0, 5, 'f', 'i', 'r', 's', 't'}, // 2-byte length prefix (big-endian) + "first"
+			expected: 0,
+			wantErr:  false,
+		},
+		{
+			name:     "valid second label",
+			data:     []byte{0, 6, 's', 'e', 'c', 'o', 'n', 'd'}, // 2-byte length prefix + "second"
+			expected: 1,
+			wantErr:  false,
+		},
+		{
+			name:     "invalid label",
+			data:     []byte{0, 7, 'i', 'n', 'v', 'a', 'l', 'i', 'd'}, // 2-byte length prefix + "invalid"
+			expected: 0,                                               // zero value
+			wantErr:  true,                                            // should error for invalid enum value
+		},
+		{
+			name:     "empty data",
+			data:     []byte{},
+			expected: 0,    // zero value
+			wantErr:  true, // should error for too short data
+		},
+		{
+			name:     "truncated data",
+			data:     []byte{0, 10, 'a', 'b'}, // claims length 10 but only has 2 chars
+			expected: 0,                       // zero value
+			wantErr:  true,                    // should error for truncated data
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := FromBinary[int](labels, tt.data)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, but got none")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("FromBinary failed: %v", err)
+				return
+			}
+
+			if result != tt.expected {
+				t.Errorf("expected %d, got %d", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestTextBinaryRoundTrip tests that marshalling and unmarshalling preserves values
+func TestTextBinaryRoundTrip(t *testing.T) {
+	labels := []string{"alpha", "beta", "gamma", "delta"}
+
+	for i, label := range labels {
+		t.Run(label, func(t *testing.T) {
+			// Test Text round trip
+			textBytes, err := ToText(labels, i)
+			if err != nil {
+				t.Errorf("ToText failed: %v", err)
+				return
+			}
+
+			textResult, err := FromText[int](labels, textBytes)
+			if err != nil {
+				t.Errorf("FromText failed: %v", err)
+				return
+			}
+
+			if textResult != i {
+				t.Errorf("Text round trip failed: expected %d, got %d", i, textResult)
+			}
+
+			// Test Binary round trip
+			binaryBytes, err := ToBinary(labels, i)
+			if err != nil {
+				t.Errorf("ToBinary failed: %v", err)
+				return
+			}
+
+			binaryResult, err := FromBinary[int](labels, binaryBytes)
+			if err != nil {
+				t.Errorf("FromBinary failed: %v", err)
+				return
+			}
+
+			if binaryResult != i {
+				t.Errorf("Binary round trip failed: expected %d, got %d", i, binaryResult)
+			}
+		})
+	}
+}
+
+// TestToBinaryLabelTooLong tests binary marshalling with very long labels
+func TestToBinaryLabelTooLong(t *testing.T) {
+	// Create a label that's longer than 65535 bytes (maximum for uint16)
+	longLabel := string(make([]byte, 65536))
+	labels := []string{longLabel}
+
+	_, err := ToBinary[int](labels, 0)
+	if err == nil {
+		t.Error("expected error for label too long, got nil")
+		return
+	}
+
+	// Verify it's the right type of error
+	var labelTooLongErr *ErrLabelTooLong
+	if !errors.As(err, &labelTooLongErr) {
+		t.Errorf("expected ErrLabelTooLong, got %T", err)
+		return
+	}
+
+	if labelTooLongErr.Length != 65536 {
+		t.Errorf("expected Length=65536, got %d", labelTooLongErr.Length)
+	}
+
+	if labelTooLongErr.MaxLength != 65535 {
+		t.Errorf("expected MaxLength=65535, got %d", labelTooLongErr.MaxLength)
+	}
+}
+
+// TestToSQLValue tests SQL value marshalling
+func TestToSQLValue(t *testing.T) {
+	labels := []string{"first", "second", "third"}
+
+	tests := []struct {
+		name     string
+		value    int
+		expected string
+		hasError bool
+	}{
+		{
+			name:     "valid first value",
+			value:    0,
+			expected: "first",
+			hasError: false,
+		},
+		{
+			name:     "valid middle value",
+			value:    1,
+			expected: "second",
+			hasError: false,
+		},
+		{
+			name:     "valid last value",
+			value:    2,
+			expected: "third",
+			hasError: false,
+		},
+		{
+			name:     "invalid value",
+			value:    5,
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := ToSQLValue[int](labels, tt.value)
+
+			if tt.hasError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+// TestFromSQLValue tests SQL value unmarshalling
+func TestFromSQLValue(t *testing.T) {
+	labels := []string{"alpha", "beta", "gamma"}
+
+	tests := []struct {
+		name          string
+		src           any
+		expectedValue int
+		hasError      bool
+	}{
+		{
+			name:          "string first",
+			src:           "alpha",
+			expectedValue: 0,
+			hasError:      false,
+		},
+		{
+			name:          "string middle",
+			src:           "beta",
+			expectedValue: 1,
+			hasError:      false,
+		},
+		{
+			name:          "string last",
+			src:           "gamma",
+			expectedValue: 2,
+			hasError:      false,
+		},
+		{
+			name:          "bytes",
+			src:           []byte("alpha"),
+			expectedValue: 0,
+			hasError:      false,
+		},
+		{
+			name:          "nil value",
+			src:           nil,
+			expectedValue: 0,
+			hasError:      false,
+		},
+		{
+			name:     "invalid string",
+			src:      "invalid",
+			hasError: true,
+		},
+		{
+			name:     "invalid type",
+			src:      123,
+			hasError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := FromSQLValue[int](labels, tt.src)
+
+			if tt.hasError {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if result != tt.expectedValue {
+				t.Errorf("expected value %d, got %d", tt.expectedValue, result)
+			}
+		})
+	}
+}
+
+// TestSQLRoundTrip tests SQL marshalling round trip
+func TestSQLRoundTrip(t *testing.T) {
+	labels := []string{"one", "two", "three"}
+	testValues := []int{0, 1, 2}
+
+	for _, value := range testValues {
+		t.Run("round trip", func(t *testing.T) {
+			// Convert to SQL value
+			sqlValue, err := ToSQLValue[int](labels, value)
+			if err != nil {
+				t.Fatalf("ToSQLValue failed: %v", err)
+			}
+
+			// Convert back from SQL value
+			result, err := FromSQLValue[int](labels, sqlValue)
+			if err != nil {
+				t.Fatalf("FromSQLValue failed: %v", err)
+			}
+
+			// Verify round trip
+			if result != value {
+				t.Errorf("round trip failed: original %d, got %d", value, result)
+			}
+		})
 	}
 }


### PR DESCRIPTION
- Implement encoding.TextMarshaler/TextUnmarshaler interfaces
- Implement encoding.BinaryMarshaler/BinaryUnmarshaler interfaces
- Add ToText/FromText functions in internal/marshal.go
- Add ToBinary/FromBinary functions with length-prefixed format
- Add comprehensive test coverage for all new functionality
- Update README.md with marshalling interfaces documentation
- Support for INI, TOML, query strings, binary streams use cases