### PR TITLE
feat: add compile-time interface verification for Wrapper

### DIFF
--- a/wrapper.go
+++ b/wrapper.go
@@ -1,7 +1,10 @@
 package enum
 
 import (
+	"database/sql"
 	"database/sql/driver"
+	"encoding"
+	"encoding/json"
 
 	"github.com/gmllt/enum/internal"
 )
@@ -11,6 +14,18 @@ type Wrapper[T Value] struct {
 	Enum    *Enum[T]
 	Current T
 }
+
+// Ensure Wrapper implements the necessary interfaces.
+var (
+	_ json.Marshaler             = (*Wrapper[int])(nil)
+	_ json.Unmarshaler           = (*Wrapper[int])(nil)
+	_ encoding.TextMarshaler     = (*Wrapper[int])(nil)
+	_ encoding.TextUnmarshaler   = (*Wrapper[int])(nil)
+	_ encoding.BinaryMarshaler   = (*Wrapper[int])(nil)
+	_ encoding.BinaryUnmarshaler = (*Wrapper[int])(nil)
+	_ driver.Valuer              = (*Wrapper[int])(nil)
+	_ sql.Scanner                = (*Wrapper[int])(nil)
+)
 
 // NewWrapper creates a new Wrapper with the given labels.
 func NewWrapper[T Value](labels ...string) Wrapper[T] {


### PR DESCRIPTION
Add compile-time checks to ensure Wrapper[T] properly implements all marshalling interfaces:

- json.Marshaler and json.Unmarshaler
- encoding.TextMarshaler and encoding.TextUnmarshaler
- encoding.BinaryMarshaler and encoding.BinaryUnmarshaler
- driver.Valuer and sql.Scanner

This provides early detection of interface compliance issues and improves code maintainability by catching regressions at compile-time rather than runtime.

The verification uses the standard Go idiom of blank identifier assignments with nil pointer casts to validate interface implementation without runtime overhead.